### PR TITLE
opentelemetry-instrumentation-haystack 0.49.6 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "opentelemetry-instrumentation-haystack" %}
-{% set version = "0.47.2" %}
+{% set version = "0.49.6" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_')}}-{{ version }}.tar.gz
-  sha256: 8d382e4d14127d632042440baaf0bb224a8e728dde08961164ad7686f224e3fe
+  sha256: 54eb274cbcf4381b9d476efc3203d87eb4a67e687497db47ec491e390390062c
 
 build:
   number: 0
@@ -21,9 +21,9 @@ requirements:
     - poetry-core
   run:
     - python
-    - opentelemetry-api >=1.28.0,<2.0.0
-    - opentelemetry-instrumentation >=0.50b0
-    - opentelemetry-semantic-conventions >=0.50b0
+    - opentelemetry-api >=1.38.0,<2.0.0
+    - opentelemetry-instrumentation >=0.59b0
+    - opentelemetry-semantic-conventions >=0.59b0
     - opentelemetry-semantic-conventions-ai >=0.4.13,<0.5
   run_constrained:
     - haystack-ai >=2.0,<2.4


### PR DESCRIPTION
opentelemetry-instrumentation-haystack 0.49.6 

**Destination channel:** Defaults

### Links

- [PKG-11116]
- dev_url:        https://github.com/traceloop/openllmetry/tree/0.49.6
- conda_forge:    https://github.com/conda-forge/opentelemetry-instrumentation-haystack-feedstock
- pypi:           https://pypi.org/project/opentelemetry-instrumentation-haystack/0.49.6
- pypi inspector: https://inspector.pypi.io/project/opentelemetry-instrumentation-haystack/0.49.6

### Explanation of changes:

- new version number


[PKG-11116]: https://anaconda.atlassian.net/browse/PKG-11116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ